### PR TITLE
Switch Render start command to HTTP mode

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: gmx-mcp
     env: python
     buildCommand: pip install -r requirements.txt
-    startCommand: python server.py --mode ws --host 0.0.0.0 --port $PORT --path /
+    startCommand: python server.py --mode http --host 0.0.0.0 --port $PORT --path /
     plan: free
     autoDeploy: true
     envVars:


### PR DESCRIPTION
## Summary
- update the Render deployment configuration to start the server in HTTP mode instead of WebSocket mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c84e835b88832ea2c2840708708899